### PR TITLE
Parse Gemfile for reek version if 'gemfile' version is selected

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM ruby:2.6-alpine
 ENV REVIEWDOG_VERSION v0.10.2
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-RUN apk add --update --no-cache build-base git
+
+# hadolint ignore=DL3018
+RUN apk add --update --no-cache build-base git grep
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ $REVIEWDOG_VERSION
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ With `reporter: github-pr-review` a comment is added to the Pull Request Convers
 
 ### `reek_version`
 
-Optional. Set reek version. 
-By default, the latest version is installed.
+Optional. Set reek version. Possible values:
+* empty or omit: install latest version
+* `gemfile`: install version from Gemfile (`Gemfile.lock` should be presented, otherwise it will fallback to latest bundler version)
+* version (e.g. `6.0.0`): install said version
 
 ### `reek_flags`
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,29 @@ version() {
 cd "$GITHUB_WORKSPACE"
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-gem install -N reek $(version $INPUT_REEK_VERSION)
+# if 'gemfile' reek version selected
+if [[ $INPUT_REEK_VERSION = "gemfile" ]]; then
+  # if Gemfile.lock is here
+  if [[ -f 'Gemfile.lock' ]]; then
+    # grep for reek version
+    REEK_GEMFILE_VERSION=`cat Gemfile.lock | grep -oP '^\s{4}reek\s\(\K.*(?=\))'`
+
+    # if reek version found, then pass it to the gem install
+    # left it empty otherwise, so no version will be passed
+    if [[ -n "$REEK_GEMFILE_VERSION" ]]; then
+      REEK_VERSION=$REEK_GEMFILE_VERSION
+      else
+        printf "Cannot get the reek's version from Gemfile.lock. The latest version will be installed."
+    fi
+    else
+      printf 'Gemfile.lock not found. The latest version will be installed.'
+  fi
+  else
+    # set desired reek version
+    REEK_VERSION=$INPUT_REEK_VERSION
+fi
+
+gem install -N reek $(version $REEK_VERSION)
 
 reek --single-line . ${INPUT_REEK_FLAGS} \
   | reviewdog -f=reek \


### PR DESCRIPTION
- Add ability to parse `Gemfile.lock` for reek version, if `gemfile` reek version is selected. Install latest bundler or fixed version otherwise.
- Add `grep` to Dockerfile in order to use GNU grep with PCRE support.
- Update readme.