### PR TITLE
Do not use sudo to install reek

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
   using: 'composite'
   steps:
     - run: $GITHUB_ACTION_PATH/script.sh
-      shell: bash
+      shell: sh
       env:
         REVIEWDOG_VERSION: v0.11.0
         # INPUT_<VARIABLE_NAME> is not available in Composite run steps


### PR DESCRIPTION
* There is an issue with some environments and system-wide gem
installation.
* Fix shell syntax.

See: https://github.com/reviewdog/action-reek/pull/18#discussion_r564335215

This action won't work on self-hosted runners without ruby at all (obvious). Default Ubuntu 18.04, 20.04 runners contains default ruby, but somehow `script.sh` should install gem for a user e.g. `--user-install`. Or the `reviewdog/action-reek` action should require some ruby installation where possible install gem without sudo. E.g. from `ruby/setup-ruby@v1`