### PR TITLE
Exit from action step with correct exit code.

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -54,4 +54,9 @@ reek --single-line . ${INPUT_REEK_FLAGS} \
     -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
     -level="${INPUT_LEVEL}" \
     ${INPUT_REVIEWDOG_FLAGS}
+
+reviewdog_rc=$?
+
 echo '::endgroup::'
+
+exit $reviewdog_rc


### PR DESCRIPTION
By default shell exits with exit code from latest command.
In this case this is 'echo' that always exits with 0 exit code.