### PR TITLE
Update Reviewdog version to v0.20.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: sh
       env:
-        REVIEWDOG_VERSION: v0.20.1
+        REVIEWDOG_VERSION: v0.20.2
         # INPUT_<VARIABLE_NAME> is not available in Composite run steps
         # https://github.community/t/input-variable-name-is-not-available-in-composite-run-steps/127611
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}


### PR DESCRIPTION
### Summary  
This PR updates the Reviewdog version used in the action from `v0.20.1` to `v0.20.2` to resolve an issue related to the `-fail-level` flag.

### Problem  
In the current configuration, Reviewdog `v0.20.1` is used, which does not support the `-fail-level` command-line option. As a result, the following error occurs:  
```
flag provided but not defined: -fail-level  
Usage: reviewdog [flags]  
  reviewdog accepts any compiler or linter results from stdin and filters  
  them by diff for review. reviewdog also can post the results as a comment  
  to GitHub if you use reviewdog in CI service.
```

### Cause  
The `-fail-level` option was introduced in Reviewdog `v0.20.2`. (ref: https://github.com/reviewdog/reviewdog/commit/2927b7ecf285fd745644ca3f61e3d0d1a5eca0a7 )

However, the current version in use (`v0.20.1`) does not include this feature.

### Changes Made  
- Updated the Reviewdog version in the configuration file to `v0.20.2`.
